### PR TITLE
make sure cumulusci.yml hasn't changed from master

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -3,3 +3,5 @@ from .base import *  # NOQA
 CHANNEL_LAYERS = {
     "default": {"BACKEND": "metecho.tests.layer_utils.MockedRedisInMemoryChannelLayer"}
 }
+
+DEVHUB_USERNAME = None


### PR DESCRIPTION
In order to prevent execution of code that we haven't reviewed, this adds a check to confirm that cumulusci.yml is unchanged from master.