### PR TITLE
Fixes for private repos and which files to commit

### DIFF
--- a/metecho/api/admin.py
+++ b/metecho/api/admin.py
@@ -4,7 +4,6 @@ from django.contrib.postgres.fields import JSONField
 from django.contrib.sites.admin import SiteAdmin
 from django.contrib.sites.models import Site
 from django.forms.widgets import Textarea
-from github3.exceptions import NotFoundError
 from parler.admin import TranslatableAdmin
 
 from . import gh
@@ -32,18 +31,13 @@ class RepositoryForm(forms.ModelForm):
         repo_name = cleaned_data.get("repo_name")
         repo_owner = cleaned_data.get("repo_owner")
 
+        # Make sure we can access the repository
         try:
             gh.get_repo_info(None, repo_owner=repo_owner, repo_name=repo_name)
-        except NotFoundError:
+        except Exception:
             raise forms.ValidationError(
-                "No repository with this name and owner exists."
-            )
-        try:
-            app = gh.gh_as_app()
-            app.app_installation_for_repository(repo_owner, repo_name)
-        except NotFoundError:
-            raise forms.ValidationError(
-                "The associated GitHub app is not installed for that repository."
+                f"Could not access {repo_owner}/{repo_name} using GitHub app. "
+                "Does the Metecho app need to be installed for this repository?"
             )
 
 

--- a/metecho/api/gh.py
+++ b/metecho/api/gh.py
@@ -44,11 +44,13 @@ def gh_given_user(user):
     return login(token=token)
 
 
-def gh_as_app():
+def gh_as_app(repo_owner, repo_name):
     app_id = settings.GITHUB_APP_ID
-    pem = settings.GITHUB_APP_KEY
+    app_key = settings.GITHUB_APP_KEY
     gh = GitHub()
-    gh.login_as_app(pem, app_id)
+    gh.login_as_app(app_key, app_id, expire_in=120)
+    installation = gh.app_installation_for_repository(repo_owner, repo_name)
+    gh.login_as_app_installation(app_key, app_id, installation.id)
     return gh
 
 
@@ -69,7 +71,7 @@ def zip_file_is_safe(zip_file):
 
 
 def get_repo_info(user, repo_id=None, repo_owner=None, repo_name=None):
-    gh = gh_given_user(user) if user else gh_as_app()
+    gh = gh_given_user(user) if user else gh_as_app(repo_owner, repo_name)
     if repo_id is None:
         return gh.repository(repo_owner, repo_name)
     return gh.repository_with_id(repo_id)

--- a/metecho/api/sf_org_changes.py
+++ b/metecho/api/sf_org_changes.py
@@ -161,8 +161,9 @@ def commit_changes_to_github(
         )
         repo = get_repo_info(user, repo_id=repo_id)
         author = {"name": user.username, "email": user.email}
+        local_dir = os.path.join(project_path, target_directory)
         CommitDir(repo, author=author)(
-            project_path, branch, repo_dir="", commit_message=commit_message
+            local_dir, branch, repo_dir=target_directory, commit_message=commit_message
         )
 
 

--- a/metecho/api/tests/admin.py
+++ b/metecho/api/tests/admin.py
@@ -1,4 +1,3 @@
-from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,30 +20,9 @@ class TestRepositoryForm:
             get_repo_info.side_effect = NotFoundError(MagicMock())
             assert not form.is_valid()
             assert form.errors == {
-                "__all__": ["No repository with this name and owner exists."],
-            }
-
-    def test_clean__app_not_installed(self, user_factory):
-        form = RepositoryForm(
-            {"name": "Test", "repo_owner": "test", "repo_name": "test"}
-        )
-        # This is how the user gets there in real circumstances, just
-        # jammed on:
-        form.user = user_factory()
-        with ExitStack() as stack:
-            stack.enter_context(patch("metecho.api.admin.gh.get_repo_info"))
-            gh_as_app = stack.enter_context(patch("metecho.api.admin.gh.gh_as_app"))
-            gh_as_app.return_value = MagicMock(
-                **{
-                    "app_installation_for_repository.side_effect": NotFoundError(
-                        MagicMock()
-                    ),
-                }
-            )
-            assert not form.is_valid()
-            assert form.errors == {
                 "__all__": [
-                    "The associated GitHub app is not installed for that repository."
+                    "Could not access test/test using GitHub app. "
+                    "Does the Metecho app need to be installed for this repository?"
                 ],
             }
 

--- a/metecho/api/tests/gh.py
+++ b/metecho/api/tests/gh.py
@@ -44,7 +44,7 @@ class TestGetAllOrgRepos:
 
 def test_gh_as_app():
     with patch("metecho.api.gh.GitHub"):
-        assert gh_as_app() is not None
+        assert gh_as_app("TestOrg", "TestRepo") is not None
 
 
 def test_is_safe_path():


### PR DESCRIPTION
This contains 2 unrelated fixes:
1. Trying to verify existence of a private repository gets a 404 even if it exists if we have not authenticated as the github app's _specific installation for that repo_. This means we don't have a good way to distinguish between repos that don't exist and repos that we can't see, so I consolidated the checks in RepositoryForm.clean
2. When committing retrieved changes, only look for files to commit in the target directory, not the entire project. This will help avoid picking up changes in .sfdx even if the CommitDir util from cumulusci isn't truly honoring .gitignore yet.