### PR TITLE
Feature/secrev fixes

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,8 +2,18 @@
 import os
 import sys
 
+ALLOWED_PRODUCTION_COMMANDS = [
+    "collectstatic",
+    "promote_superuser",
+    "migrate",
+    "rqscheduler",
+    "rqworker",
+    "showmigrations",
+]
+
+
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    settings_module = os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:
@@ -19,4 +29,10 @@ if __name__ == "__main__":
                 "forget to activate a virtual environment?"
             )
         raise
+
+    if len(sys.argv) > 1 and settings_module == "config.settings.production":
+        command = sys.argv[1]
+        if command not in ALLOWED_PRODUCTION_COMMANDS:
+            raise RuntimeError(f"Access to the {command} command has been disabled in production.")
+
     execute_from_command_line(sys.argv)

--- a/manage.py
+++ b/manage.py
@@ -33,6 +33,8 @@ if __name__ == "__main__":
     if len(sys.argv) > 1 and settings_module == "config.settings.production":
         command = sys.argv[1]
         if command not in ALLOWED_PRODUCTION_COMMANDS:
-            raise RuntimeError(f"Access to the {command} command has been disabled in production.")
+            raise RuntimeError(
+                f"Access to the {command} command has been disabled in production."
+            )
 
     execute_from_command_line(sys.argv)

--- a/metecho/api/tests/jobs.py
+++ b/metecho/api/tests/jobs.py
@@ -539,12 +539,12 @@ class TestPopulateGithubUsers:
             collab1 = MagicMock(
                 id=123,
                 login="test-user-1",
-                avatar_url="http://example.com/avatar1.png",
+                avatar_url="https://example.com/avatar1.png",
             )
             collab2 = MagicMock(
                 id=456,
                 login="test-user-2",
-                avatar_url="http://example.com/avatar2.png",
+                avatar_url="https://example.com/avatar2.png",
             )
             repo = MagicMock(**{"collaborators.return_value": [collab1, collab2]})
             get_repo_info.return_value = repo


### PR DESCRIPTION
Following up on some requests from our security folks:
1. Restrict which Django management commands can be used in production
2. Don't use http:// in test data