### PR TITLE
Sanitize email content to prevent XSS injection

### DIFF
--- a/metecho/api/models.py
+++ b/metecho/api/models.py
@@ -1,3 +1,4 @@
+import html
 import logging
 from datetime import timedelta
 
@@ -80,6 +81,10 @@ class User(HashIdMixin, AbstractUser):
     def notify(self, subject, body):
         # Right now, the only way we notify is via email. In future, we
         # may add in-app notifications.
+
+        # Escape <>& in case the email gets accidentally rendered as HTML
+        subject = html.escape(subject)
+        body = html.escape(body)
         send_mail(
             subject,
             body,


### PR DESCRIPTION
Avoid possible XSS injection (this content shouldn't be user-sourced and should be delivered as a text/plain email, but security asked us to do this anyway as a security-in-depth measure)