### PR TITLE
[bugfix] I do not want it to auto-toggle sending assignment email alert

### DIFF
--- a/src/js/components/user/githubUser.tsx
+++ b/src/js/components/user/githubUser.tsx
@@ -330,21 +330,34 @@ export const AssignUserModal = ({
 
   const [selection, setSelection] = useState<GitHubUser | null>(null);
   const [shouldAlertAssignee, setShouldAlertAssignee] = useState(true);
+  const [autoToggle, setAutoToggle] = useState(false);
   const handleAlertAssignee = (
     event: React.FormEvent<HTMLFormElement>,
     { checked }: { checked: boolean },
   ) => {
     setShouldAlertAssignee(checked);
+    if (event.currentTarget.id) {
+      // do automatically toggle sending an alert if user explicity says no thanks
+      setAutoToggle(shouldAlertAssignee);
+    }
   };
-  const handleAssigneeSelection = (user: GitHubUser) => {
+  const handleAssigneeSelection = (
+    event: React.FormEvent<HTMLFormElement>,
+    user: GitHubUser,
+  ) => {
     const currentUserSelected = user.login === currentUser.username;
-    setShouldAlertAssignee(!currentUserSelected);
     setSelection(user);
+    if (currentUserSelected) {
+      handleAlertAssignee(event, { checked: false });
+    } else if (!autoToggle) {
+      handleAlertAssignee(event, { checked: true });
+    }
   };
   const handleClose = () => {
     onRequestClose();
     setSelection(null);
     setShouldAlertAssignee(true);
+    setAutoToggle(false);
   };
   const handleSave = () => {
     setUser(selection, shouldAlertAssignee);
@@ -386,6 +399,7 @@ export const AssignUserModal = ({
           [
             <Checkbox
               key="alert"
+              id="alert"
               labels={{ label: checkboxLabel }}
               className="slds-float_left slds-p-top_xx-small"
               name={alertType}
@@ -435,7 +449,9 @@ export const AssignUserModal = ({
                 <GitHubUserButton
                   user={user}
                   isSelected={selection === user}
-                  onClick={() => handleAssigneeSelection(user)}
+                  onClick={(event: React.FormEvent<HTMLFormElement>) =>
+                    handleAssigneeSelection(event, user)
+                  }
                 />
               </li>
             ))}

--- a/src/js/components/user/githubUser.tsx
+++ b/src/js/components/user/githubUser.tsx
@@ -330,34 +330,26 @@ export const AssignUserModal = ({
 
   const [selection, setSelection] = useState<GitHubUser | null>(null);
   const [shouldAlertAssignee, setShouldAlertAssignee] = useState(true);
-  const [autoToggle, setAutoToggle] = useState(false);
+  const [autoToggle, setAutoToggle] = useState(true);
   const handleAlertAssignee = (
     event: React.FormEvent<HTMLFormElement>,
     { checked }: { checked: boolean },
   ) => {
     setShouldAlertAssignee(checked);
-    if (event.currentTarget.id) {
-      // do automatically toggle sending an alert if user explicity says no thanks
-      setAutoToggle(shouldAlertAssignee);
-    }
+    setAutoToggle(false);
   };
-  const handleAssigneeSelection = (
-    event: React.FormEvent<HTMLFormElement>,
-    user: GitHubUser,
-  ) => {
+  const handleAssigneeSelection = (user: GitHubUser) => {
     const currentUserSelected = user.login === currentUser.username;
     setSelection(user);
-    if (currentUserSelected) {
-      handleAlertAssignee(event, { checked: false });
-    } else if (!autoToggle) {
-      handleAlertAssignee(event, { checked: true });
+    if (autoToggle) {
+      setShouldAlertAssignee(!currentUserSelected);
     }
   };
   const handleClose = () => {
     onRequestClose();
     setSelection(null);
     setShouldAlertAssignee(true);
-    setAutoToggle(false);
+    setAutoToggle(true);
   };
   const handleSave = () => {
     setUser(selection, shouldAlertAssignee);
@@ -399,7 +391,6 @@ export const AssignUserModal = ({
           [
             <Checkbox
               key="alert"
-              id="alert"
               labels={{ label: checkboxLabel }}
               className="slds-float_left slds-p-top_xx-small"
               name={alertType}
@@ -449,9 +440,7 @@ export const AssignUserModal = ({
                 <GitHubUserButton
                   user={user}
                   isSelected={selection === user}
-                  onClick={(event: React.FormEvent<HTMLFormElement>) =>
-                    handleAssigneeSelection(event, user)
-                  }
+                  onClick={() => handleAssigneeSelection(user)}
                 />
               </li>
             ))}

--- a/test/js/components/projects/detail.test.jsx
+++ b/test/js/components/projects/detail.test.jsx
@@ -508,7 +508,7 @@ describe('<ProjectDetail/>', () => {
         expect(updateObject.mock.calls[0][0].data.should_alert_qa).toBe(false);
       });
 
-      test('assigning developer', () => {
+      test('does not auto toggle when assigning user (developer)', () => {
         const { getAllByText, baseElement, getByText } = setup();
         fireEvent.click(getAllByText('Assign Developer')[0]);
         fireEvent.click(getByText('Notify Assigned Developer by Email'));
@@ -517,7 +517,7 @@ describe('<ProjectDetail/>', () => {
         );
         fireEvent.click(getByText('Save'));
 
-        expect(updateObject.mock.calls[0][0].data.should_alert_dev).toBe(true);
+        expect(updateObject.mock.calls[0][0].data.should_alert_dev).toBe(false);
       });
     });
   });


### PR DESCRIPTION
## Cute animal pic
![ffbaedd8a584d730e2570771ecf9d7a4](https://user-images.githubusercontent.com/12376362/87975925-43d49100-ca9a-11ea-8293-e3afc905cb97.jpg)



## Link to Trello card (if applicable)
https://trello.com/c/Dfl03CRc


## Description
- [ ] Description is in Trello card



## Steps to test/reproduce
Alert Assignee Modal in:
Project Detail -> Assign user from Task Table &
Task Detail -> Assign user from Org Card



## Show me
![Screenshot from 2020-07-20 15-10-48](https://user-images.githubusercontent.com/12376362/87976519-3d92e480-ca9b-11ea-8724-4dfe6fe4c232.png)
