### PR TITLE
Re-add branch and commit to project_config when fetching task config names.

### DIFF
--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -760,11 +760,14 @@ def available_task_org_config_names(epic, *, user):
             repo_name=epic.project.repo_name,
         )
         with local_github_checkout(user, repo_id) as repo_root:
+            branch_name = epic.branch_name or epic.get_base()
             config = get_project_config(
                 repo_root=repo_root,
                 repo_name=repo.name,
                 repo_url=repo.html_url,
                 repo_owner=repo.owner.login,
+                repo_branch=branch_name,
+                repo_commit=repo.branch(branch_name).latest_sha(),
             )
             epic.available_task_org_config_names = [
                 {"key": key, **value} for key, value in config.orgs__scratch.items()

--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -760,14 +760,13 @@ def available_task_org_config_names(epic, *, user):
             repo_name=epic.project.repo_name,
         )
         with local_github_checkout(user, repo_id) as repo_root:
-            branch_name = epic.branch_name or epic.get_base()
             config = get_project_config(
                 repo_root=repo_root,
                 repo_name=repo.name,
                 repo_url=repo.html_url,
                 repo_owner=repo.owner.login,
-                repo_branch=branch_name,
-                repo_commit=repo.branch(branch_name).latest_sha(),
+                repo_branch=repo.default_branch,
+                repo_commit=repo.branch(repo.default_branch).latest_sha(),
             )
             epic.available_task_org_config_names = [
                 {"key": key, **value} for key, value in config.orgs__scratch.items()


### PR DESCRIPTION
## Cute animal pic
_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._

![](https://images.unsplash.com/photo-1601029711299-4fd1882be34f?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1351&q=80)

@davisagli This explicitly reverts the changes made in SFDO-Tooling/Metecho/pull/333 -- let me know if you prefer a different solution.