### PR TITLE
Only store manually-set repository images

### DIFF
--- a/metecho/api/jobs.py
+++ b/metecho/api/jobs.py
@@ -566,9 +566,12 @@ def get_social_image(*, project):
         logger.error(tb)
         raise
     else:
-        project.refresh_from_db()
-        project.repo_image_url = og_image
-        project.finalize_get_social_image()
+        # Save the image only if it was manually set by the repository owner. GitHub
+        # seems to store only manually-set images under this domain:
+        if og_image.startswith("https://repository-images.githubusercontent.com/"):
+            project.refresh_from_db()
+            project.repo_image_url = og_image
+            project.finalize_get_social_image()
 
 
 get_social_image_job = job(get_social_image)

--- a/metecho/api/tests/jobs.py
+++ b/metecho/api/tests/jobs.py
@@ -1034,7 +1034,17 @@ class TestAvailableTaskOrgConfigNames:
 
 
 @pytest.mark.django_db
-def test_get_social_image(project_factory):
+@pytest.mark.parametrize(
+    "img_url, expected",
+    (
+        (
+            "https://repository-images.githubusercontent.com/repo.png",
+            "https://repository-images.githubusercontent.com/repo.png",
+        ),
+        ("https://example.com/repo.png", ""),
+    ),
+)
+def test_get_social_image(project_factory, img_url, expected):
     project = project_factory()
     with ExitStack() as stack:
         stack.enter_context(patch("metecho.api.jobs.get_repo_info"))
@@ -1043,16 +1053,18 @@ def test_get_social_image(project_factory):
             content="""
             <html>
                 <head>
-                <meta property="og:image" content="https://example.com/">
+                <meta property="og:image" content="{}">
                 </head>
                 <body></body>
             </html>
-            """
+            """.format(
+                img_url
+            )
         )
         get_social_image(project=project)
 
         project.refresh_from_db()
-        assert project.repo_image_url == "https://example.com/"
+        assert project.repo_image_url == expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Cute animal pic
![](https://source.unsplash.com/featured/?cute,animal&210521)



## Link to Trello card (if applicable)
https://trello.com/c/Jtur1CJp/



## Description
_The commit messages say what you did; this should explain why and/or how._
- [x] Description is in Trello card



## Steps to test/reproduce

If you don't care about losing your database content, the easiest way to test is `python manage.py truncate_data` and `python manage.py populate_data`.  This will clear all `Project`s and fetch fresh images when re-populating.

Otherwise you will need to manually clear `Project.repo_image_url` and save, which will trigger the corresponding job and after a few seconds you should have the right image, or nothing if the repo hasn't set one manually.

## Show me
Repos without manually-set images will get a generic icon instead of the og:image generated by GitHub. In this screenshot only Metecho-Test has a manually-set image

![image](https://user-images.githubusercontent.com/2391102/119203819-40f75380-ba51-11eb-9700-47b30c6a2dae.png)

