### PR TITLE
[project-columns] switch columns for a11y & small, reorder on large

### DIFF
--- a/src/js/components/utils/detailPageLayout.tsx
+++ b/src/js/components/utils/detailPageLayout.tsx
@@ -151,17 +151,9 @@ const DetailPageLayout = ({
         <div
           className="slds-col
             slds-size_1-of-1
-            slds-medium-size_8-of-12
-            slds-large-size_7-of-12
-            slds-p-bottom_x-large"
-        >
-          {children}
-        </div>
-        <div
-          className="slds-col
-            slds-size_1-of-1
             slds-medium-size_4-of-12
-            slds-large-size_5-of-12"
+            slds-large-size_5-of-12
+            slds-medium-order_2"
         >
           {description && (
             <PageDescription
@@ -171,6 +163,15 @@ const DetailPageLayout = ({
             />
           )}
           {sidebar}
+        </div>
+        <div
+          className="slds-col
+            slds-size_1-of-1
+            slds-medium-size_8-of-12
+            slds-large-size_7-of-12
+            slds-p-bottom_x-large"
+        >
+          {children}
         </div>
       </div>
     </>


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&asdfghjkl)


## Description

Column order on small screens on project detail should be the Intro Title/Description on top (sidebar) and then the Epic/Task table on bottom. This is also better for accessibility. 

With CSS, I re-ordered the sidebar to be on the right when we reach the medium breakpoint. 


## Steps to test/reproduce
Look at a project detail page on large and small browser width. 

## Show me
![image](https://user-images.githubusercontent.com/1581694/131171743-5e73f854-e0e9-4f5e-b90c-33b63fcb6e05.png)


