### PR TITLE
[remove-scroll] Use % instead of vw for container

### DIFF
--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -72,7 +72,7 @@ const App = withRouter(
 
     return (
       <DocumentTitle title={i18n.t('Metecho')}>
-        <div className="slds-grid slds-grid_frame slds-grid_vertical">
+        <div className="slds-grid slds-grid_frame slds-grid_vertical metecho-frame">
           <ErrorBoundary>
             <Header />
             <div className="slds-grow slds-shrink-none">

--- a/src/js/index.tsx
+++ b/src/js/index.tsx
@@ -72,7 +72,12 @@ const App = withRouter(
 
     return (
       <DocumentTitle title={i18n.t('Metecho')}>
-        <div className="slds-grid slds-grid_frame slds-grid_vertical metecho-frame">
+        <div
+          className="slds-grid
+            slds-grid_frame
+            slds-grid_vertical
+            metecho-frame"
+        >
           <ErrorBoundary>
             <Header />
             <div className="slds-grow slds-shrink-none">

--- a/src/sass/patterns/_containers.scss
+++ b/src/sass/patterns/_containers.scss
@@ -1,7 +1,7 @@
 // Containers
 // ==========
 
-.metecho-frame {
+// Prevent unwanted horizontal scroll by overriding the 100vw applied by slds-grid_frame
   min-width: 100%;
 }
 

--- a/src/sass/patterns/_containers.scss
+++ b/src/sass/patterns/_containers.scss
@@ -1,6 +1,10 @@
 // Containers
 // ==========
 
+.metecho-frame {
+  min-width: 100%;
+}
+
 // Restrict fixed/absolute containers to half the viewport
 // ie. used on toast containers to unblock header links
 .half-container {

--- a/src/sass/patterns/_containers.scss
+++ b/src/sass/patterns/_containers.scss
@@ -2,6 +2,7 @@
 // ==========
 
 // Prevent unwanted horizontal scroll by overriding the 100vw applied by slds-grid_frame
+.metecho-frame {
   min-width: 100%;
 }
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -49,7 +49,7 @@
   </head>
   <body>
     <main id="app" class="slds-grid slds-grid_vertical">
-      <div class="slds-grid slds-grid_frame slds-grid_vertical">
+      <div class="slds-grid slds-grid_frame slds-grid_vertical metecho-frame">
         <div class="slds-page-header global-header slds-p-horizontal_x-large slds-p-vertical_medium">
           <div class="slds-page-header__row">
             <div class="slds-page-header__col-title">


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&adsdfdsadfsa)

Wanted to remove the unecessary horizontal scroll.


## Steps to test/reproduce
View a task or epic page that scrolls vertically. See if horizontal scrollbar is also present.


## Show me
Screenshot on top shows the "after" view, bottom is before
![after-before-scrollbar](https://user-images.githubusercontent.com/1581694/135676150-ab83be1b-e7ba-479b-ac2c-e86dd191a867.jpg)
.
