### PR TITLE
Simplify model choices

### DIFF
--- a/metecho/api/migrations/0040_task_status.py
+++ b/metecho/api/migrations/0040_task_status.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("Planned", "Planned"),
-                    ("In progress", "In progress"),
+                    ("In progress", "In Progress"),
                     ("Completed", "Completed"),
                 ],
                 default="Planned",

--- a/metecho/api/migrations/0054_task_review_status.py
+++ b/metecho/api/migrations/0054_task_review_status.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 choices=[
                     ("Approved", "Approved"),
-                    ("Changes requested", "Changes requested"),
+                    ("Changes requested", "Changes Requested"),
                 ],
                 max_length=32,
                 null=True,

--- a/metecho/api/migrations/0061_fix_project_status.py
+++ b/metecho/api/migrations/0061_fix_project_status.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("Planned", "Planned"),
-                    ("In progress", "In progress"),
+                    ("In progress", "In Progress"),
                     ("Review", "Review"),
                     ("Merged", "Merged"),
                 ],

--- a/metecho/api/migrations/0083_remove_all_null_strings.py
+++ b/metecho/api/migrations/0083_remove_all_null_strings.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 choices=[
                     ("Approved", "Approved"),
-                    ("Changes requested", "Changes requested"),
+                    ("Changes requested", "Changes Requested"),
                 ],
                 default="",
                 max_length=32,

--- a/metecho/api/migrations/0103_alter_task_status.py
+++ b/metecho/api/migrations/0103_alter_task_status.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 choices=[
                     ("Planned", "Planned"),
-                    ("In progress", "In progress"),
+                    ("In progress", "In Progress"),
                     ("Completed", "Completed"),
                     ("Canceled", "Canceled"),
                 ],

--- a/metecho/api/models.py
+++ b/metecho/api/models.py
@@ -50,35 +50,35 @@ logger = logging.getLogger(__name__)
 
 
 class OrgType(models.TextChoices):
-    PRODUCTION = ("Production", "Production")
-    SCRATCH = ("Scratch", "Scratch")
-    SANDBOX = ("Sandbox", "Sandbox")
-    DEVELOPER = ("Developer", "Developer")
+    PRODUCTION = "Production"
+    SCRATCH = "Scratch"
+    SANDBOX = "Sandbox"
+    DEVELOPER = "Developer"
 
 
 class ScratchOrgType(models.TextChoices):
-    DEV = ("Dev", "Dev")
+    DEV = "Dev"
     QA = ("QA", "QA")
-    PLAYGROUND = ("Playground", "Playground")
+    PLAYGROUND = "Playground"
 
 
 class EpicStatus(models.TextChoices):
-    PLANNED = ("Planned", "Planned")
-    IN_PROGRESS = ("In progress", "In progress")
-    REVIEW = ("Review", "Review")
-    MERGED = ("Merged", "Merged")
+    PLANNED = "Planned"
+    IN_PROGRESS = "In progress"
+    REVIEW = "Review"
+    MERGED = "Merged"
 
 
 class TaskStatus(models.TextChoices):
-    PLANNED = ("Planned", "Planned")
-    IN_PROGRESS = ("In progress", "In progress")
-    COMPLETED = ("Completed", "Completed")
-    CANCELED = ("Canceled", "Canceled")
+    PLANNED = "Planned"
+    IN_PROGRESS = "In progress"
+    COMPLETED = "Completed"
+    CANCELED = "Canceled"
 
 
 class TaskReviewStatus(models.TextChoices):
-    APPROVED = ("Approved", "Approved")
-    CHANGES_REQUESTED = ("Changes requested", "Changes requested")
+    APPROVED = "Approved"
+    CHANGES_REQUESTED = "Changes requested"
 
 
 class SiteProfile(TranslatableModel):


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2112092)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Follow up to #1808. This removes a lot of the repetition on the choices. The changes to the migrations are for the human-readable names displayed in the admin (the second value of the tuple), the actual DB values remain the same.