### PR TITLE
Fix django-rq config for SSL Redis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -400,7 +400,9 @@ JS_REVERSE_EXCLUDE_NAMESPACES = ["admin", "admin_rest"]
 
 # Redis configuration:
 
-REDIS_LOCATION = "{0}/{1}".format(env("REDIS_URL", default="redis://localhost:6379"), 0)
+REDIS_LOCATION = "{}/0".format(
+    env("REDIS_TLS_URL", default=env("REDIS_URL", default="redis://localhost:6379"))
+)
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,7 +1,7 @@
 import ssl
 
 from .base import *  # NOQA
-from .base import CACHES, CHANNEL_LAYERS, PROJECT_ROOT, REDIS_LOCATION, TEMPLATES
+from .base import CHANNEL_LAYERS, PROJECT_ROOT, REDIS_LOCATION, RQ_QUEUES, TEMPLATES
 
 STATICFILES_DIRS = [
     str(PROJECT_ROOT / "static"),
@@ -21,8 +21,14 @@ if REDIS_LOCATION.startswith("rediss://"):
     # See:
     #   - https://github.com/django/channels_redis/issues/235
     #   - https://github.com/jazzband/django-redis/issues/353
+    #   - https://paltman.com/how-to-turn-off-ssl-verify-django-rq-heroku-redis/
 
-    CACHES["default"]["OPTIONS"]["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": False}
+    RQ_QUEUES["default"].update(
+        {
+            "SSL": True,
+            "SSL_CERT_REQS": None,
+        }
+    )
 
     ssl_context = ssl.SSLContext()
     ssl_context.check_hostname = False


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&211221)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce
We'll see if this works once we deploy to Heroku