### PR TITLE
Use a custom connection pool in production

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -407,6 +407,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": REDIS_LOCATION,
+        "OPTIONS": {},
     }
 }
 RQ_QUEUES = {

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,7 +1,14 @@
 import ssl
 
 from .base import *  # NOQA
-from .base import CHANNEL_LAYERS, PROJECT_ROOT, REDIS_LOCATION, RQ_QUEUES, TEMPLATES
+from .base import (
+    CACHES,
+    CHANNEL_LAYERS,
+    PROJECT_ROOT,
+    REDIS_LOCATION,
+    RQ_QUEUES,
+    TEMPLATES,
+)
 
 STATICFILES_DIRS = [
     str(PROJECT_ROOT / "static"),
@@ -22,6 +29,8 @@ if REDIS_LOCATION.startswith("rediss://"):
     #   - https://github.com/django/channels_redis/issues/235
     #   - https://github.com/jazzband/django-redis/issues/353
     #   - https://paltman.com/how-to-turn-off-ssl-verify-django-rq-heroku-redis/
+
+    CACHES["default"]["OPTIONS"]["pool_class"] = "metecho.redis.SSLConnectionPool"
 
     RQ_QUEUES["default"].update(
         {

--- a/metecho/redis.py
+++ b/metecho/redis.py
@@ -1,0 +1,11 @@
+from redis.connection import ConnectionPool, SSLConnection
+
+
+class SSLConnectionPool(ConnectionPool):
+    """Connection pool that disable SSL checks by default"""
+
+    def __init__(
+        self, connection_class=SSLConnection, max_connections=None, **connection_kwargs
+    ):
+        connection_kwargs.setdefault("ssl_cert_reqs", False)
+        super().__init__(connection_class, max_connections, **connection_kwargs)

--- a/metecho/redis.py
+++ b/metecho/redis.py
@@ -7,5 +7,5 @@ class SSLConnectionPool(ConnectionPool):
     def __init__(
         self, connection_class=SSLConnection, max_connections=None, **connection_kwargs
     ):
-        connection_kwargs.setdefault("ssl_cert_reqs", False)
+        connection_kwargs.setdefault("ssl_cert_reqs", None)
         super().__init__(connection_class, max_connections, **connection_kwargs)

--- a/metecho/tests/redis.py
+++ b/metecho/tests/redis.py
@@ -1,0 +1,6 @@
+from metecho.redis import SSLConnectionPool
+
+
+def test_pool():
+    pool = SSLConnectionPool()
+    assert not pool.connection_kwargs["ssl_cert_reqs"]


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&211222)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
It looks like Django's Redis cache backend only accepts 4 options: [serializer, pool_class, db, and parser_class](https://github.com/django/django/blob/stable/4.0.x/django/core/cache/backends/redis.py#L35-L38). What we want to do is set the [`ssl_cert_reqs` kwarg](https://github.com/redis/redis-py/blob/64791a5/redis/connection.py#L832) of SSLConnection to `None`. Ideally Django would provide a way to pass connection kwargs all the way from settings but that's not the case, so we need to override the pool class instead.
