### PR TITLE
fix nested accordion padding

### DIFF
--- a/src/sass/patterns/_form-elements.scss
+++ b/src/sass/patterns/_form-elements.scss
@@ -28,12 +28,6 @@
     }
   }
 
-  .slds-is-open {
-    > .slds-accordion__summary {
-      margin-bottom: $spacing-x-small;
-    }
-  }
-
   .grow-inner-item {
     .slds-accordion__summary-action > .slds-truncate {
       flex-grow: 1;
@@ -41,15 +35,9 @@
   }
 
   .accordion-no-padding {
-    > .slds-accordion__list-item {
-      > .slds-is-open {
-        padding: 0;
-
-        > .slds-accordion__summary {
-          padding-top: $spacing-x-small;
-          padding-left: $spacing-medium;
-          padding-right: $spacing-medium;
-        }
+    .slds-is-open {
+      .slds-accordion__section {
+        padding-right: 0;
       }
     }
   }
@@ -57,7 +45,8 @@
 
 .metecho-nested-checkboxes {
   // line up with above label; add grid + (faux checkbox + label margin)
-  padding-left: $square-icon-x-small-boundary + $spacing-large;
+  // twice left padding of accordion + icon and icon margin spacing
+  padding-left: 2.875rem;
 }
 
 [data-form='create-epic-branch'] {

--- a/src/sass/patterns/_form-elements.scss
+++ b/src/sass/patterns/_form-elements.scss
@@ -19,7 +19,19 @@
   }
 
   .slds-accordion__section {
-    padding: $spacing-x-small $spacing-medium;
+    --slds-c-accordion-section-spacing-block-start: #{$spacing-x-small};
+    --slds-c-accordion-section-spacing-block-end: #{$spacing-x-small};
+    --slds-c-accordion-section-spacing-inline-start: #{$spacing-medium};
+    --slds-c-accordion-section-spacing-inline-end: #{$spacing-medium};
+  }
+
+  .accordion-no-padding {
+    .slds-is-open {
+      .slds-accordion__section {
+        --slds-c-accordion-section-spacing-inline-start: #{$spacing-large};
+        --slds-c-accordion-section-spacing-inline-end: 0;
+      }
+    }
   }
 
   &.has-checkboxes {
@@ -33,20 +45,11 @@
       flex-grow: 1;
     }
   }
-
-  .accordion-no-padding {
-    .slds-is-open {
-      .slds-accordion__section {
-        padding-right: 0;
-      }
-    }
-  }
 }
 
 .metecho-nested-checkboxes {
   // line up with above label; add grid + (faux checkbox + label margin)
-  // twice left padding of accordion + icon and icon margin spacing
-  padding-left: 2.875rem;
+  padding-left: $square-icon-x-small-boundary + $spacing-large;
 }
 
 [data-form='create-epic-branch'] {


### PR DESCRIPTION
Layout would break when expanding ignored changes accordion in the retrieve changes modal. 

## Screenshot

**Before and After**

![me-changes-modal](https://user-images.githubusercontent.com/1581694/169411668-09ed6c82-899c-4ca8-84bd-103394f3aee5.jpg)

## To Test

- Make a dev org on a task or use existing one if you have one
- Make some changes to the org (see pinned instructions if you don't know how in Slack). 
- Open the "Retrieve Changes from Dev Org" modal
- Leave the first screen on the default selection and choose "Save & Next"
- Then select a checkbox from the All changes list and choose "Ignore Selected Changes"
- Expand the Ignored changes if they weren't already and see if the spacing looks correct.


## Trello
https://trello.com/c/cbaMfIcq/362-layout-breaks-when-expanding-ignored-changes-accordion