### PR TITLE
Misc cleanup

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -13,12 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Determine node version
-        run:
-          echo "NODE_VERSION=$(grep -oP 'node\K\d+' Dockerfile)" >> $GITHUB_ENV
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ env.NODE_VERSION }}'
+          node-version-file: .nvmrc
           cache: yarn
       - run: yarn install --frozen--lockfile
       - run: yarn deploy-storybook --ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /app
 ENV PYTHONPATH /app
 ENV DJANGO_SETTINGS_MODULE config.settings.production
 
+# Install sfdx
+RUN npm install --location=global sfdx-cli --ignore-scripts
+
 # Python requirements:
 COPY ./requirements requirements
 RUN pip install --no-cache-dir --upgrade pip pip-tools \
@@ -15,9 +18,6 @@ RUN pip install --no-cache-dir --upgrade pip pip-tools \
 RUN if [ "${BUILD_ENV}" = "development" ] ; then \
     pip install --no-cache-dir -r requirements/dev.txt; \
     fi
-
-# Install sfdx
-RUN npm install --location=global sfdx-cli --ignore-scripts
 
 # JS client setup:
 COPY ./package.json package.json


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&2205273)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
A few things we picked up from our recent work on MetaDeploy:

- Move the installation of `sfdx-cli` higher up in the `Dockerfile` so that layer is cached
- Read the node version from `.nvmrc` instead of using regex in `deploy-storybook` workflow